### PR TITLE
remove download link for microsoft store

### DIFF
--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -30,12 +30,12 @@ function DownloadOptions() {
             <div className={styles.column}>
                 <FontAwesomeIcon icon={faWindows} size="4x" />
                 <h2>Windows</h2>
-                <Link
+                {/* <Link
                     className="button button--primary button--lg"
                     href="https://apps.microsoft.com/detail/Nyrna/9p9s8kz41grj?launch=true
                     &mode=mini">
                     Microsoft Store
-                </Link>
+                </Link> */}
                 <Link
                     className="button button--primary button--lg"
                     // href="https://github.com/Merrit/nyrna/releases/latest/download/Nyrna-Windows-Installer.exe">


### PR DESCRIPTION
Since we can't test against Windows 11 and we can't restrict sale to only Window 10 we disabled sale on the Microsoft Store, therefore we are also removing the download link for the Microsoft Store until such time as we can test against Windows 11 and re-enable sale on the Microsoft Store.